### PR TITLE
Fix LoadStopWords comment

### DIFF
--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ func IsStopWord(needle string) bool {
 	return false
 }
 
-// LoadStopWords takes list of paths and reads the contents in to the stopWords array.
+// LoadStopWords reads stop words from a single file path into the stopWords map.
 func LoadStopWords(path string) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
## Summary
- clarify `LoadStopWords` comment to reflect single path input

## Testing
- `gofmt -w util.go`
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840da876eec8324864d59109b370e7d