### PR TITLE
Fix label typo in chart config

### DIFF
--- a/static/gui/index.html
+++ b/static/gui/index.html
@@ -613,7 +613,7 @@ body.dark-theme .fa {
               window.colors.grey
             ]
           }],
-          labels: ["Positive","Negative","Nuetral"]},
+          labels: ["Positive","Negative","Neutral"]},
         options: {
           responsive: true,
           circumference: 1*Math.PI,


### PR DESCRIPTION
## Summary
- fix spelling of Neutral label in total sentiment chart

## Testing
- `go vet ./...` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840da7578cc8324889aba120d97a73d